### PR TITLE
out vector should be of size nClasses for softmax

### DIFF
--- a/src/FastForest.cpp
+++ b/src/FastForest.cpp
@@ -60,7 +60,7 @@ std::vector<TreeEnsembleResponseType> fastforest::FastForest::softmax(const Feat
                                  std::to_string(nClasses) + " classes!");
     }
 
-    auto out = std::vector<TreeEnsembleResponseType>(3);
+    auto out = std::vector<TreeEnsembleResponseType>(nClasses);
 
     for (int iClass = 0; iClass < nClasses; ++iClass) {
         int iRootIndex = 0;


### PR DESCRIPTION
I was running into a malloc error when I tried to requery the boosted model. I think it was due to the incorrect vector size.