### PR TITLE
Encode correct base response already when reading the model

### DIFF
--- a/.github/workflows/fastforest-ci.yml
+++ b/.github/workflows/fastforest-ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -DEXPERIMENTAL_TMVA_SUPPORT:bool=true -DCMAKE_INSTALL_PREFIX=../install ..
+          cmake -DEXPERIMENTAL_TMVA_SUPPORT:bool=OFF -DCMAKE_INSTALL_PREFIX=../install ..
           cmake --build . --target install -j2
 
       - name: Prepare test data

--- a/README.md
+++ b/README.md
@@ -34,16 +34,24 @@ In the end, we save the model both in __binary format__ to be able to still read
 format__ so we can open it with FastForest.
 
 ```Python
+import xgboost
 from xgboost import XGBClassifier
 from sklearn.datasets import make_classification
 import numpy as np
 
-X, y = make_classification(n_samples=10000, n_features=5, random_state=42, n_classes=2, weights=[0.5])
+X, y = make_classification(
+    n_samples=10000, n_features=5, random_state=42, n_classes=2, weights=[0.5]
+)
 
 model = XGBClassifier().fit(X, y)
-booster = model._Booster
 
-booster.dump_model("model.txt")
+outfile = "model.txt"
+# Dump the model to a .txt file
+model._Booster.dump_model(outfile, fmap="", with_stats=False, dump_format="text")
+# Append the XGBoost version, required for correct parsing because of XGBoost
+#  version differences.
+with open(outfile, "a") as f:
+    f.write(f"xgboost_version={xgboost.__version__}\n")
 ```
 
 In C++, you can now quickly load the model into a `FastForest` and obtain predictions by calling the FastForest object with an array of features.

--- a/include/fastforest.h
+++ b/include/fastforest.h
@@ -47,11 +47,6 @@ namespace fastforest {
     // Set to `unsigned char` for most compact fastforest ofjects if you have less than 256 features.
     typedef unsigned int CutIndexType;
 
-    // The base response you have to use with older XGBoost versions might be
-    // zero, so try to explicitly pass zero to the model evaluation if the
-    // results from this library are incorrect.
-    const TreeEnsembleResponseType defaultBaseResponse = 0.0;
-
     namespace details {
 
         void softmaxTransformInplace(TreeEnsembleResponseType* out, int nOut);
@@ -59,32 +54,25 @@ namespace fastforest {
     }
 
     struct FastForest {
-        inline TreeEnsembleResponseType operator()(const FeatureType* array,
-                                                   TreeEnsembleResponseType baseResponse = defaultBaseResponse) const {
-            return evaluateBinary(array, baseResponse);
-        }
+        inline TreeEnsembleResponseType operator()(const FeatureType* array) const { return evaluateBinary(array); }
 
 #if __cplusplus >= 201103L
         template <int nClasses>
-        std::array<TreeEnsembleResponseType, nClasses> softmax(
-            const FeatureType* array, TreeEnsembleResponseType baseResponse = defaultBaseResponse) const {
+        std::array<TreeEnsembleResponseType, nClasses> softmax(const FeatureType* array) const {
             // static softmax interface: no manual memory allocation, but requires to know nClasses at compile time
             static_assert(nClasses >= 3, "nClasses should be >= 3");
             std::array<TreeEnsembleResponseType, nClasses> out{};
-            evaluate(array, out.data(), nClasses, baseResponse);
+            evaluate(array, out.data(), nClasses);
             details::softmaxTransformInplace(out.data(), nClasses);
             return out;
         }
 #endif
 
         // dynamic softmax interface with manually allocated std::vector: simple but inefficient
-        std::vector<TreeEnsembleResponseType> softmax(
-            const FeatureType* array, TreeEnsembleResponseType baseResponse = defaultBaseResponse) const;
+        std::vector<TreeEnsembleResponseType> softmax(const FeatureType* array) const;
 
         // softmax interface that is not a pure function, but no manual allocation and no compile-time knowledge needed
-        void softmax(const FeatureType* array,
-                     TreeEnsembleResponseType* out,
-                     TreeEnsembleResponseType baseResponse = defaultBaseResponse) const;
+        void softmax(const FeatureType* array, TreeEnsembleResponseType* out) const;
 
         void write_bin(std::string const& filename) const;
 
@@ -100,12 +88,9 @@ namespace fastforest {
         std::vector<TreeEnsembleResponseType> baseResponses_;
 
       private:
-        void evaluate(const FeatureType* array,
-                      TreeEnsembleResponseType* out,
-                      int nOut,
-                      TreeEnsembleResponseType baseResponse) const;
+        void evaluate(const FeatureType* array, TreeEnsembleResponseType* out, int nOut) const;
 
-        TreeEnsembleResponseType evaluateBinary(const FeatureType* array, TreeEnsembleResponseType baseResponse) const;
+        TreeEnsembleResponseType evaluateBinary(const FeatureType* array) const;
     };
 
     FastForest load_txt(std::string const& txtpath, std::vector<std::string>& features, int nClasses = 2);

--- a/src/fastforest.cpp
+++ b/src/fastforest.cpp
@@ -55,16 +55,13 @@ void fastforest::details::softmaxTransformInplace(TreeEnsembleResponseType* out,
     }
 }
 
-std::vector<TreeEnsembleResponseType> fastforest::FastForest::softmax(const FeatureType* array,
-                                                                      TreeEnsembleResponseType baseResponse) const {
+std::vector<TreeEnsembleResponseType> fastforest::FastForest::softmax(const FeatureType* array) const {
     std::vector<TreeEnsembleResponseType> out(nClasses());
-    softmax(array, out.data(), baseResponse);
+    softmax(array, out.data());
     return out;
 }
 
-void fastforest::FastForest::softmax(const FeatureType* array,
-                                     TreeEnsembleResponseType* out,
-                                     TreeEnsembleResponseType baseResponse) const {
+void fastforest::FastForest::softmax(const FeatureType* array, TreeEnsembleResponseType* out) const {
     int nClass = nClasses();
     if (nClass <= 2) {
         throw std::runtime_error(
@@ -72,16 +69,13 @@ void fastforest::FastForest::softmax(const FeatureType* array,
             "the number of classes in the FastForest-creating function if this is a multiclassification model.");
     }
 
-    evaluate(array, out, nClass, baseResponse);
+    evaluate(array, out, nClass);
     fastforest::details::softmaxTransformInplace(out, nClass);
 }
 
-void fastforest::FastForest::evaluate(const FeatureType* array,
-                                      TreeEnsembleResponseType* out,
-                                      int nOut,
-                                      TreeEnsembleResponseType baseResponse) const {
+void fastforest::FastForest::evaluate(const FeatureType* array, TreeEnsembleResponseType* out, int nOut) const {
     for (int i = 0; i < nOut; ++i) {
-        out[i] = baseResponse + baseResponses_[i];
+        out[i] = baseResponses_[i];
     }
 
     int iRootIndex = 0;
@@ -98,9 +92,8 @@ void fastforest::FastForest::evaluate(const FeatureType* array,
     }
 }
 
-TreeEnsembleResponseType fastforest::FastForest::evaluateBinary(const FeatureType* array,
-                                                                TreeEnsembleResponseType baseResponse) const {
-    TreeEnsembleResponseType out = baseResponse + baseResponses_[0];
+TreeEnsembleResponseType fastforest::FastForest::evaluateBinary(const FeatureType* array) const {
+    TreeEnsembleResponseType out = baseResponses_[0];
 
     for (std::vector<int>::const_iterator indexIter = rootIndices_.begin(); indexIter != rootIndices_.end();
          ++indexIter) {


### PR DESCRIPTION
Encode the base response already when reading the model, depending on
the xgboost version so that we ensure correct inference results.

To ensure no errors with version mismatch can happen, the user is now
forced to add a version hint to the model dump (this will probably be
easier in the future with the JSON parser, where the XGBoost version is
part of the metadata).