### PR TITLE
Fix base_score extraction from JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ with open(outfile, "a") as f:
     import json
 
     json_dump = json.loads(booster.save_config())
-    base_score = json_dump["learner"]["learner_model_param"]["base_score"]
+    base_score_str = json_dump["learner"]["learner_model_param"]["base_score"]
+    base_score = json.loads(base_score_str)[0]  # NB: Should not contain any brackets [ or ], as C++ parsing might crash.
     f.write(f"base_score={base_score}\n")
 ```
 


### PR DESCRIPTION
Updated base_score extraction to handle string format.

I tested the curent python code on a simple example (a dummy xgboost mode) and it would crash the fast forest C++ text parsing as it contains base_score and brackets ([]) on the same line (which the C++ parsing code doesn't support).